### PR TITLE
try to find other version of the map when no config is found

### DIFF
--- a/addons/sourcemod/scripting/soap_tf2dm.sp
+++ b/addons/sourcemod/scripting/soap_tf2dm.sp
@@ -17,7 +17,7 @@
 // ====[ CONSTANTS ]===================================================
 #define PLUGIN_NAME         "SOAP TF2 Deathmatch"
 #define PLUGIN_AUTHOR       "Icewind, MikeJS, Lange, Tondark - maintained by sappho.io"
-#define PLUGIN_VERSION      "4.2.0"
+#define PLUGIN_VERSION      "4.3.0"
 #define PLUGIN_CONTACT      "https://steamcommunity.com/id/icewind1991, https://sappho.io"
 #define UPDATE_URL          "https://raw.githubusercontent.com/sapphonie/SOAP-TF2DM/master/updatefile.txt"
 


### PR DESCRIPTION
This stops "SOAP breaking" whenever a new version of a map is released.

If no config is found for a map and it can't be downloaded, it attempts to strip the version suffix (`_a4`, `b2`, etc) and looks for any config which matches the prefix.

While other versions of the config might not be a perfect fit for the updated map it should still make things justwork™ in most cases.