### PR TITLE
Handle map names with mixed case

### DIFF
--- a/addons/sourcemod/scripting/soap_tf2dm.sp
+++ b/addons/sourcemod/scripting/soap_tf2dm.sp
@@ -357,6 +357,13 @@ void InitSpawnSys()
 
     char map[64];
     GetCurrentMap(map, sizeof(map));
+    
+    // TF2 is case-insensitive when dealing with map names
+    // We lowercase it, because the following *is* case-sensitive
+    for (int i = 0; i < sizeof(map); ++i)
+    {
+        map[i] = CharToLower(map[i]);
+    }
 
     char path[256];
 


### PR DESCRIPTION
You can repro this by running a server with SOAPDM and running `rcon changelevel CP_GULLYWASH_FINAL1`, the server and the client properly load the game, the config at `cfg/cp_gullywash_final1.cfg` is properly ran if present, but SOAP fails to detect the map name.

This seems to be the only case where the handling of the map name is sensitive to case, the other uses of `GetCurrentMap` are `StrContains(map, "mge", /* caseSensitive = */ false)` and `ServerCommand("exec %s", map)`, both of which are insensitive.

Apologies about the EOF newline, I used the GitHub inline editor for this