### PR TITLE
Add support for koth_proot, bump ashville version to final

### DIFF
--- a/addons/sourcemod/configs/soap/koth_ashville_final.cfg
+++ b/addons/sourcemod/configs/soap/koth_ashville_final.cfg
@@ -1,0 +1,80 @@
+"Spawns"
+{
+	"red"
+	{
+		"Garage Door Red"
+		{
+			"origin" 	"-194.86 -870 1630.03"
+			"angles"	"1.33 89.76 0.00000"
+		}
+		"Battlements Red"
+		{
+		
+			"origin" 	"1131.46 -269.57 1832.03"
+			"angles"	"0.83 -135.98 0.000000"
+		}
+		"Rock Spawn Red"
+		{
+		
+			"origin" 	"1320.00 -1930.57 1662.09"
+			"angles"	"-0.13 179.59 0.000000"
+		}
+		"Underground Crate Red"
+		{
+		
+			"origin" 	"571.18 -370.62 1667.55"
+			"angles"	"1.03 -179.96 0.000000"
+		}
+		"Red Roof Crate"
+		{
+		
+			"origin" 	"-1057.73 -211.46 1860.28"
+			"angles"	"0.78 -43.88 0.000000"
+		}
+		"Red Yellow Barrel"
+		{
+		
+			"origin" 	"-676.75 -536.89 1687.45"
+			"angles"	"-1.49 35.21 0.000000"
+		}
+	}
+	"blue"
+	{
+		"Garage Door Blue"
+		{
+		
+			"origin" 	"89.69 851.97 1630.03"
+			"angles"	"-0.33 -89.29 0.000000"
+		}
+		"Battlements Blue"
+		{
+		
+			"origin" 	"-1247.53 249.44 1825.03"
+			"angles"	"1.46 47.90 0.000000"
+		}
+		"Rock Spawn Blue"
+		{
+		
+			"origin" 	"-1416.08 1927.55 1655.07"
+			"angles"	"-1.26 -3.49 0.000000"
+		}
+		"Underground Crate Blue"
+		{
+		
+			"origin" 	"-656.33 379.15 1668.20"
+			"angles"	"0.20 -1.52 0.000000"
+		}
+		"Blue Roof Crate"
+		{
+		
+			"origin" 	"955.86 218.40 1853.28"
+			"angles"	"0.10 137.01 0.000000"
+		}
+		"Blue Yellow Barrel"
+		{
+		
+			"origin" 	"581.99 558.42 1679.14"
+			"angles"	"1.21 -137.30 0.000000"
+		}
+	}
+}

--- a/addons/sourcemod/configs/soap/koth_proot_b5b.cfg
+++ b/addons/sourcemod/configs/soap/koth_proot_b5b.cfg
@@ -1,0 +1,79 @@
+"Spawns"
+{
+	"red"
+	{
+		"Red Upper Building"
+		{
+			"origin" 	"138.75 1452.95 68.03"
+			"angles"	"0 -115 0"
+		}
+		"Red Right Flank"
+		{
+			"origin" 	"-1426.35 279.99 116.03"
+			"angles"	"0 0 0"
+		}
+		"Red Left Ledge"
+		{
+			"origin" 	"820.05 766.13 68.03"
+			"angles"	"0 -150 0"
+		}
+		"Red Lower Building"
+		{
+			"origin" 	"-201.31 1431.18 -123.96"
+			"angles"	"0 -40 0"
+		}
+		"Red Courtyard"
+		{
+			"origin" 	"935.85 1771.91 -187.96"
+			"angles"	"0 -120 0"
+		}
+		"Red Mid Shared 1"
+		{
+			"origin" 	"450.91 -0.91 215.39"
+			"angles"	"0 -135 0"
+		}
+		"Red Mid Shared 2"
+		{
+			"origin" 	"-628.22 0.21 218.78"
+			"angles"	"0 -45 0"
+		}
+	}
+	"blue"
+	{
+		"Blu Upper Building"
+		{
+			"origin" 	"138.75 -1452.95 68.03"
+			"angles"	"0 115 0"
+		}
+		"Blu Left Flank"
+		{
+			"origin" 	"-1426.35 -279.99 116.03"
+			"angles"	"0 0 0"
+		}
+		"Blu Right Ledge"
+		{
+			"origin" 	"820.05 -766.13 68.03"
+			"angles"	"0 150 0"
+		}
+		"Blu Lower Building"
+		{
+			"origin" 	"-201.31 -1431.18 -123.96"
+			"angles"	"0 40 0"
+		}
+		"Blu Courtyard"
+		{
+			"origin" 	"935.85 -1771.91 -187.96"
+			"angles"	"0 120 0"
+		}
+		"Blu Mid Shared 1"
+		{
+			"origin" 	"450.91 -0.91 215.39"
+			"angles"	"0 135 0"
+		}
+		"Blu Mid Shared 2"
+		{
+			"origin" 	"-628.22 0.21 218.78"
+			"angles"	"0 45 0"
+		}
+	}
+}


### PR DESCRIPTION
This update provides the following

Brand new map support:
- koth_proot_b5b, in preparation for upcoming RGL highlander season 14

Updated map versions:
- Bumped koth_ashville_rc2d -> koth_ashville_final, also in preparation for upcoming RGL highlander season 14