### PR TITLE
Correct updatefile.txt version mismatch

### DIFF
--- a/addons/sourcemod/scripting/soap_tf2dm.sp
+++ b/addons/sourcemod/scripting/soap_tf2dm.sp
@@ -21,7 +21,7 @@
 // ====[ CONSTANTS ]===================================================
 #define PLUGIN_NAME         "SOAP TF2 Deathmatch"
 #define PLUGIN_AUTHOR       "Icewind, MikeJS, Lange, Tondark - maintained by sappho.io"
-#define PLUGIN_VERSION      "4.4.5"
+#define PLUGIN_VERSION      "4.4.7"
 #define PLUGIN_CONTACT      "https://steamcommunity.com/id/icewind1991, https://sappho.io"
 #define UPDATE_URL          "https://raw.githubusercontent.com/sapphonie/SOAP-TF2DM/master/updatefile.txt"
 

--- a/updatefile.txt
+++ b/updatefile.txt
@@ -4,10 +4,10 @@
 	{
 		"Version"
 		{
-			"Latest"	"4.4.5"
+			"Latest"	"4.4.7"
 		}
-		"Notes"		"Changes in 4.4.5"
-		"Notes"		"- SOAP will now not delete arena logic if mp_tournament is set to 1, as deleting arena logic breaks legitimate arena play."
+		"Notes"		"Changes in 4.4.7"
+		"Notes"		"- Corrected updater version mismatch and version number of the plugin."
 	}
 
 	"Files"


### PR DESCRIPTION
The notes in updatefile.txt are correct, however the version number is not. Thus the updater downgrades the version of the plugin. It also seems that 4.4.5 which changes up the debug command is actually 4.4.4 in the .sp file, while the plugin is 4.4.5 in the .sp file of the 4.4.6 release. This is also corrected.