### PR TITLE
Add support for eruption and mannbase, update map version for clearcut and sultry

### DIFF
--- a/addons/sourcemod/configs/soap/cp_mannbase_rc2b.cfg
+++ b/addons/sourcemod/configs/soap/cp_mannbase_rc2b.cfg
@@ -1,0 +1,69 @@
+"Spawns"
+{
+	"red"
+	{
+		"RED Left Entry"
+		{
+			"origin" "-1004 1398 185"
+			"angles" "0 -70 0"
+		}
+		"RED Left Building"
+		{
+			"origin" "-540 1243 313"
+			"angles" "0 -65 0"
+		}
+		"RED Left Building Far"
+		{
+			"origin" "271 988 185"
+			"angles" "0 -90 0"
+		}
+		"RED Barrels Mid"
+		{
+			"origin" "-739 152 147"
+			"angles" "0 -33 0"
+		}
+		"RED Jump Platform Mid Entry"
+		{
+			"origin" "-1162 -57 377"
+			"angles" "0 0 0"
+		}
+		"RED Right Entry Hill"
+		{
+			"origin" "-636 -541 316"
+			"angles" "0 32 0"
+		}
+	}
+	"blue"
+	{
+		"BLU Left Entry"
+		{
+			"origin" "1004 -1398 185"
+			"angles" "0 110 0"
+		}
+		"BLU Left Building"
+		{
+			"origin" "540 -1243 313"
+			"angles" "0 115 0"
+		}
+		"BLU Left Building Far"
+		{
+			"origin" "-271 -988 185"
+			"angles" "0 90 0"
+		}
+		"BLU Barrels Mid"
+		{
+			"origin" "739 -152 147"
+			"angles" "0 147 0"
+		}
+		"BLU Jump Platform Mid Entry"
+		{
+			"origin" "1162 57 377"
+			"angles" "0 180 0"
+		}
+		"BLU Right Entry Hill"
+		{
+			"origin" "636 541 316"
+			"angles" "0 -148 0"
+		}
+	}
+}

--- a/addons/sourcemod/configs/soap/cp_sultry_b8a.cfg
+++ b/addons/sourcemod/configs/soap/cp_sultry_b8a.cfg
@@ -1,0 +1,73 @@
+//Sultry spawns arranged and modified by JaguarFiend, 11-2022.
+//https://i.imgur.com/B711R88.jpeg
+//These spawns are mostly team sided with two chaos "purple" spawns available to both teams.
+
+"Spawns"
+{
+	"red"
+	{
+		"RED barrels"
+		{
+			"origin" "1381.31 -1218.76 708.03"
+			"angles" "0 162.14 0"
+		}
+		"RED choke"
+		{
+			"origin" "2182.80 -553.28 660.03"
+			"angles" "0 168.56 0"
+		}
+		"RED frogbox"
+		{
+			"origin" "1922.66 -125.72 644.03"
+			"angles" "0 -171.61 0"
+		}
+		"RED forward spawn"
+		{
+			"origin" "1091.21 359.48 644.03"
+			"angles" "0 -149.89 0"
+		}
+		"RED corner"
+		{
+			"origin" "50.86 -1078.50 845.96"
+			"angles" "0 51.05 0"
+		}
+		"BLU corner"
+		{
+			"origin" "-111.76 1050.55 847.12"
+			"angles" "0 -128.89 0"
+		}
+	}
+	"blue"
+	{
+		"BLU barrels"
+		{
+			"origin" "-1450.44 1185.68 708.03"
+			"angles" "0 -17.78 0"
+		}
+		"BLU choke"
+		{
+			"origin" "-2279.85 536.58 660.03"
+			"angles" "0 -11.77 0"
+		}
+		"BLU frogbox"
+		{
+			"origin" "-1978.87 92.95 644.03"
+			"angles" "0 8.25 0"
+		}
+		"BLU forward spawn"
+		{
+			"origin" "-1161.21 -391.48 644.03"
+			"angles" "0 30.10 0"
+		}
+		"BLU corner"
+		{
+			"origin" "-111.76 1050.55 847.12"
+			"angles" "0 -128.89 0"
+		}
+		"RED corner"
+		{
+			"origin" "50.86 -1078.50 845.96"
+			"angles" "0 51.05 0"
+		}
+	}
+}

--- a/addons/sourcemod/configs/soap/koth_clearcut_b17.cfg
+++ b/addons/sourcemod/configs/soap/koth_clearcut_b17.cfg
@@ -1,0 +1,83 @@
+//Clearcut spawns by ry4ntk, rearranged and modified by JaguarFiend, 1-2021.
+//https://i.imgur.com/oBv9Nod.jpg
+//These spawns are better than the totally random non-team ones since here there will be less enemies spawning perfectly behind you. On this map they're pretty much perfectly team-sided.
+
+"Spawns"
+{
+	"red"
+	{
+		"red left ramp"
+		{
+			"origin" "72.42 5177.86 140.03"
+			"angles" "0 -91.92 0"
+		}
+		"red tower perch"
+		{
+			"origin" "-445.02 4688.02 12.03"
+			"angles" "0 -48.15 0"
+		}
+		"red flank pack"
+		{
+			"origin" "-1293.86 4778.47 -78.63"
+			"angles" "0 42.05 0"
+		}
+		"red by saw"
+		{
+			"origin" "-1047.86 4404.87 40.0"
+			"angles" "0 -0.92 0"
+		}
+		"red in house"
+		{
+			"origin" "-1296.59 4147.38 -35.98"
+			"angles" "0 -46.91 0"
+		}
+		"red shed back door"
+		{
+			"origin" "-604.96 3239.44 -75.96"
+			"angles" "0 89.78 0"
+		}
+		"red in shed"
+		{
+			"origin" "-199.96 3489.04 -35.96"
+			"angles" "0 87.23 0"
+		}
+	}
+	"blue"
+	{
+		"blu left ramp"
+		{
+			"origin" "-75.70 3276.89 140.03"
+			"angles" "0 88.44 0"
+		}
+		"blu tower perch"
+		{
+			"origin" "444.66 3759.62 12.03"
+			"angles" "0 130.07 0"
+		}
+		"blu flank pack"
+		{
+			"origin" "1291.60 3669.15 -78.46"
+			"angles" "0 -136.67 0"
+		}
+		"blue by saw"
+		{
+			"origin" "1036.47 4055.33 40.0"
+			"angles" "0 179.99 0"
+		}
+		"blu in house"
+		{
+			"origin" "1292.98 4296.10 -35.96"
+			"angles" "0 132.27 0"
+		}
+		"blu shed back door"
+		{
+			"origin" "602.96 5206.42 -75.96"
+			"angles" "0 -89.93 0"
+		}
+		"blu in shed"
+		{
+			"origin" "197.55 4979.90 -35.96"
+			"angles" "0 -93.54 0"
+		}
+	}
+}

--- a/addons/sourcemod/configs/soap/pl_eruption_b14.cfg
+++ b/addons/sourcemod/configs/soap/pl_eruption_b14.cfg
@@ -1,0 +1,119 @@
+"Spawns"
+{
+	"red"
+	{
+		"spawn 0"
+		{
+			"origin"	"-5477 1061 -425"
+			"angles"	"0 -37 0"
+		}
+		"spawn 1"
+		{
+			"origin"	"-4243 1457 -440"
+			"angles"	"0 -115 0"
+		}
+		"spawn 2"
+		{
+			"origin"	"-3309 723 -75"
+			"angles"	"0 -145 0"
+		}
+		"spawn 3"
+		{
+			"origin"	"-2755 962 -140"
+			"angles"	"0 -100 0"
+		}
+		"spawn 4"
+		{
+			"origin"	"-2244 910 -335"
+			"angles"	"0 -125 0"
+		}
+		"spawn 5"
+		{
+			"origin"	"-1833 23 -416"
+			"angles"	"0 175 0"
+		}
+		"spawn 6"
+		{
+			"origin"	"-2356 -316 -166"
+			"angles"	"0 143 0"
+		}
+		"spawn 7"
+		{
+			"origin"	"-2317 -688 -133"
+			"angles"	"0 145 0"
+		}
+		"spawn 8"
+		{
+			"origin"	"-3426 -228 -31"
+			"angles"	"0 57 0"
+		}
+		"spawn 9"
+		{
+			"origin"	"-3169 -884 -70"
+			"angles"	"0 118 0"
+		}
+		"spawn 10"
+		{
+			"origin"	"-4659 -391 -210"
+			"angles"	"0 45 0"
+		}
+	}
+	"blue"
+	{
+		"spawn 0"
+		{
+			"origin"	"-5477 1061 -425"
+			"angles"	"0 -37 0"
+		}
+		"spawn 1"
+		{
+			"origin"	"-4243 1457 -440"
+			"angles"	"0 -115 0"
+		}
+		"spawn 2"
+		{
+			"origin"	"-3309 723 -75"
+			"angles"	"0 -145 0"
+		}
+		"spawn 3"
+		{
+			"origin"	"-2755 962 -140"
+			"angles"	"0 -100 0"
+		}
+		"spawn 4"
+		{
+			"origin"	"-2244 910 -335"
+			"angles"	"0 -125 0"
+		}
+		"spawn 5"
+		{
+			"origin"	"-1833 23 -416"
+			"angles"	"0 175 0"
+		}
+		"spawn 6"
+		{
+			"origin"	"-2356 -316 -166"
+			"angles"	"0 143 0"
+		}
+		"spawn 7"
+		{
+			"origin"	"-2317 -688 -133"
+			"angles"	"0 145 0"
+		}
+		"spawn 8"
+		{
+			"origin"	"-3426 -228 -31"
+			"angles"	"0 57 0"
+		}
+		"spawn 9"
+		{
+			"origin"	"-3169 -884 -70"
+			"angles"	"0 118 0"
+		}
+		"spawn 10"
+		{
+			"origin"	"-4659 -391 -210"
+			"angles"	"0 45 0"
+		}
+	}
+}


### PR DESCRIPTION
This update provides the following

Brand new map support:

- pl_eruption_b14
- cp_mannbase_rc2b

Map version updates:

- koth_clearcut_b16a -> koth_clearcut_b17 (Note: b17 is made by QueeQuey with permission from the original map author SturmTea)
- cp_sultry_b8 -> cp_sultry_b8a