### PR TITLE
Match multiple suffixes when normalizing maps

### DIFF
--- a/addons/sourcemod/scripting/soap_tf2dm.sp
+++ b/addons/sourcemod/scripting/soap_tf2dm.sp
@@ -21,7 +21,7 @@
 // ====[ CONSTANTS ]===================================================
 #define PLUGIN_NAME         "SOAP TF2 Deathmatch"
 #define PLUGIN_AUTHOR       "Icewind, MikeJS, Lange, Tondark - maintained by sappho.io"
-#define PLUGIN_VERSION      "4.4.7"
+#define PLUGIN_VERSION      "4.4.8"
 #define PLUGIN_CONTACT      "https://steamcommunity.com/id/icewind1991, https://sappho.io"
 #define UPDATE_URL          "https://raw.githubusercontent.com/sapphonie/SOAP-TF2DM/master/updatefile.txt"
 

--- a/addons/sourcemod/scripting/soap_tf2dm.sp
+++ b/addons/sourcemod/scripting/soap_tf2dm.sp
@@ -244,7 +244,7 @@ public void OnPluginStart()
     // Create configuration file in cfg/sourcemod folder
     AutoExecConfig(true, "soap_tf2dm", "sourcemod");
 
-    g_normalizeMapRegex = new Regex("(_(a|b|beta|u|r|v|rc|f|final|comptf|ugc)?[0-9]*[a-z]?$)|([0-9]+[a-z]?$)", 0);
+    g_normalizeMapRegex = new Regex("(_((a|b|beta|u|r|v|rc|f|final|comptf|ugc)?[0-9]*[a-z]?)*$)|([0-9]+[a-z]?$)", 0);
 
     GetRealClientCount();
 


### PR DESCRIPTION
This ensures it can also deal with map names like `cp_granary_pro_rc17a3`